### PR TITLE
Make `Pooled` hold the semaphore permit

### DIFF
--- a/qp/src/pool.rs
+++ b/qp/src/pool.rs
@@ -3,11 +3,12 @@ use crate::resource::Factory;
 use crossbeam_queue::ArrayQueue;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
-use tokio::sync::Semaphore;
+use tokio::sync::{Semaphore, SemaphorePermit};
 
 pub struct Pooled<'a, F: Factory> {
     pool: &'a Inner<F>,
     resource: Option<F::Output>,
+    _permit: SemaphorePermit<'a>,
 }
 
 impl<F: Factory> Deref for Pooled<'_, F> {
@@ -28,7 +29,6 @@ impl<F: Factory> Drop for Pooled<'_, F> {
     fn drop(&mut self) {
         if let Some(resource) = self.resource.take() {
             let _ = self.pool.resources.push(resource);
-            self.pool.semaphore.add_permits(1);
         }
     }
 }
@@ -84,26 +84,28 @@ struct Inner<F: Factory> {
 impl<F: Factory> Inner<F> {
     pub async fn acquire(&self) -> Result<Pooled<'_, F>> {
         // A `Semaphore::acquire` can only fail if the semaphore has been closed.
-        self.semaphore
+        let permit = self
+            .semaphore
             .acquire()
             .await
-            .map_err(|_| Error::PoolClosed)?
-            .forget();
+            .map_err(|_| Error::PoolClosed)?;
         Ok(Pooled {
             pool: self,
             resource: Some(self.pop_or_create_resource().await?),
+            _permit: permit,
         })
     }
 
     pub async fn acquire_unchecked(&self) -> Result<Pooled<'_, F>> {
-        self.semaphore
+        let permit = self
+            .semaphore
             .acquire()
             .await
-            .map_err(|_| Error::PoolClosed)?
-            .forget();
+            .map_err(|_| Error::PoolClosed)?;
         Ok(Pooled {
             pool: self,
             resource: Some(self.pop_or_create_resource_unchecked().await?),
+            _permit: permit,
         })
     }
 
@@ -136,6 +138,5 @@ impl<F: Factory> Inner<F> {
 }
 
 pub fn take_resource<F: Factory>(mut guard: Pooled<'_, F>) -> F::Output {
-    guard.pool.semaphore.add_permits(1);
     guard.resource.take().unwrap()
 }


### PR DESCRIPTION
Remove handcrafted semaphore acquisition / release to reduce human error.
This also makes it easier to use runtimes other than tokio.