### PR TITLE
Add tests for aborted Pool::acquire and Semaphore::acquire calls showing a memory leak

### DIFF
--- a/qp/src/pool.rs
+++ b/qp/src/pool.rs
@@ -159,9 +159,9 @@ impl<M: Manage> Pooled<'_, M> {
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::atomic::{AtomicUsize, Ordering}, time::Duration};
-
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
     #[derive(Default)]
     struct Manager {

--- a/qp/src/pool.rs
+++ b/qp/src/pool.rs
@@ -156,3 +156,55 @@ impl<M: Manage> Pooled<'_, M> {
         pooled.resource.take().unwrap()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::atomic::{AtomicUsize, Ordering}, time::Duration};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct Manager {
+        creation_counter: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl Manage for Manager {
+        type Output = ();
+        type Error = ();
+        async fn try_create(&self) -> Result<Self::Output, Self::Error> {
+            assert_eq!(self.creation_counter.fetch_add(1, Ordering::Relaxed), 0);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_abort_acquire() {
+        let pool = Pool::new(Manager::default(), 1);
+        // Grab the only object from the pool
+        let obj = pool.acquire().await;
+        // Spawn two tokio tasks waiting for an object.
+        // The first one times out after 1ms and the second
+        // after 3ms.
+        let a = {
+            let pool = pool.clone();
+            tokio::spawn(tokio::time::timeout(Duration::from_millis(1), async move {
+                let _ = pool.acquire().await;
+            }))
+        };
+        tokio::time::sleep(Duration::from_millis(1)).await;
+        let b = {
+            let pool = pool.clone();
+            tokio::spawn(tokio::time::timeout(Duration::from_millis(2), async move {
+                let _ = pool.acquire().await;
+            }))
+        };
+        tokio::time::sleep(Duration::from_millis(1)).await;
+        // The first task should now be timed out.
+        drop(obj);
+        // The first task should have timed out and returned an error
+        // while the second task should've gotten hold of the object.
+        assert!(a.await.unwrap().is_err());
+        assert!(b.await.unwrap().is_ok());
+    }
+}

--- a/qp/src/sync.rs
+++ b/qp/src/sync.rs
@@ -163,7 +163,9 @@ impl<'a> Acquire<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{sync::Arc, time::Duration};
+    use std::sync::Arc;
+    use std::time::Duration;
+
     #[tokio::test]
     async fn test_abort_acquire() {
         let sem = Arc::new(Semaphore::new(1));


### PR DESCRIPTION
I wanted to show the reason for the deadlock I reported in #2 but found a memory leak instead.

A aborted `Semaphore::acquire` does leave the waker behind in the queue which causes the memory to grow indefinitely.

The thing I don't understand: I wanted to show that the aborted task A leaves a waker for itself in the queue and when the permit is returned task A is woken instead of task B thus causing the code to deadlock. This does not happen. Instead I found that calling `waker.wake()` for task A actually wakes task B.

I'm trying to wrap my head around why it works that way and doesn't deadlock. Whatever the reason for that behavior is. It's a memory leak nonetheless.